### PR TITLE
fix bug (probably)

### DIFF
--- a/frontend/src/components/editor/EditorPane.tsx
+++ b/frontend/src/components/editor/EditorPane.tsx
@@ -36,12 +36,17 @@ function setupMonacoModels({
       !model ||
       (typeof model.isDisposed === "function" && model.isDisposed())
     ) {
-      model = monaco.editor.createModel(
-        file.fileContent || "",
-        getMonacoLang(file.fileName),
-        uri
-      );
-      modelsRef.current[file.fileName] = model;
+      model = monaco.editor.getModel(uri);
+      if (model) {
+        modelsRef.current[file.fileName] = model;
+      } else {
+        model = monaco.editor.createModel(
+          file.fileContent || "",
+          getMonacoLang(file.fileName),
+          uri
+        );
+        modelsRef.current[file.fileName] = model;
+      }
     } else if (
       model.getValue() !== file.fileContent &&
       file.fileContent !== ""
@@ -59,12 +64,17 @@ function setupMonacoModels({
     !model ||
     (typeof model.isDisposed === "function" && model.isDisposed())
   ) {
-    model = monaco.editor.createModel(
-      fileContent,
-      getMonacoLang(activeTab),
-      uri
-    );
-    modelsRef.current[activeTab] = model;
+    model = monaco.editor.getModel(uri);
+    if (model) {
+      modelsRef.current[activeTab] = model;
+    } else {
+      model = monaco.editor.createModel(
+        fileContent,
+        getMonacoLang(activeTab),
+        uri
+      );
+      modelsRef.current[activeTab] = model;
+    }
   } else if (model.getValue() !== fileContent && fileContent !== "") {
     model.setValue(fileContent);
   }


### PR DESCRIPTION
fixes monaco bug when going back and forward between the editor page and other pages in browser

```
Error: ModelService: Cannot add model because it already exists!
    at u._createModelData (https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/editor/editor.main.js:692:3358)
    at u.createModel (https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/editor/editor.main.js:692:3583)
    at H (https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/editor/editor.main.js:739:159)
    at q (https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/editor/editor.main.js:739:105)
    at Object.U [as createModel] (https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/editor/editor.main.js:739:16348)
    at http://localhost:3000/src/screens/ProjectEditor.tsx:333:39
    at Array.forEach (<anonymous>)
    at http://localhost:3000/src/screens/ProjectEditor.tsx:330:20
    at react-stack-bottom-frame (http://localhost:3000/node_modules/.vite/deps/react-dom_client.js?v=92a1468a:17732:20)
    at runWithFiberInDEV (http://localhost:3000/node_modules/.vite/deps/react-dom_client.js?v=92a1468a:1540:72)
```