### PR TITLE
feat: backend slugify project name

### DIFF
--- a/backend/controllers/projectController.ts
+++ b/backend/controllers/projectController.ts
@@ -5,7 +5,7 @@ import generateToken from "../utils/generateToken";
 import fs from "fs";
 import { IProject, IProjectFile } from "../../shared/types";
 import { userInfo } from "os";
-
+import slugify from "slugify";
 const findProject = async (projectName: string): Promise<IProject> => {
   let starterExists: boolean = false;
   try {
@@ -306,10 +306,11 @@ const findProjectById = async (projectId: string): Promise<IProject> => {
 };
 const changeProjectName = asyncHandler(async (req: any, res) => {
   const { projectId, newProjectName } = req.body;
-  const foundProject: IProject = await findProject(newProjectName);
+  const slugifiedProjectName = slugify(newProjectName, { replacement: '-', lower: true, strict: true });
+  const foundProject: IProject = await findProject(slugifiedProjectName);
   if (foundProject) {
     res.status(400);
-    throw new Error(`:( project with name ${newProjectName} already exists :(`);
+    throw new Error(`:( project with name ${slugifiedProjectName} already exists :(`);
   }
 
   if (!projectId || !newProjectName) {
@@ -329,7 +330,7 @@ const changeProjectName = asyncHandler(async (req: any, res) => {
   try {
     await Project.findOneAndUpdate(
       { projectId },
-      { projectName: newProjectName }
+      { projectName: slugifiedProjectName }
     );
   } catch (error) {
     console.error("Error updating project name:", error);
@@ -343,7 +344,8 @@ const changeProjectName = asyncHandler(async (req: any, res) => {
 
   res.json({
     message: "Project name updated",
-    projectName: project.projectName
+    projectName: slugifiedProjectName,
+    originalName: newProjectName
   });
 });
 

--- a/frontend/src/components/editor/SettingsPane.tsx
+++ b/frontend/src/components/editor/SettingsPane.tsx
@@ -73,21 +73,29 @@ const SettingsPane = ({
   const handleSave = async () => {
     let didChange = false;
     if (changeProjectName && nameInput && nameInput !== effectiveProjectName) {
-      if ((await changeProjectName(nameInput)) == false) {
+      try {
+        const result = await changeProjectName(nameInput);
+        if (result !== false) {
+          didChange = true;
+          // Update the text input with the slugified name returned from backend
+          if (result && result.projectName) {
+            setNameInput(result.projectName);
+            dispatch(setCurrentProjectName(result.projectName));
+          } else {
+            dispatch(setCurrentProjectName(nameInput));
+          }
+        }
+      } catch (error) {
+        console.error("Error changing project name:", error);
         didChange = false;
-      } else {
-        didChange = true;
-        dispatch(setCurrentProjectName(nameInput));
       }
     }
     if (changeProjectDescription && descInput !== effectiveProjectDescription) {
       await changeProjectDescription(descInput);
-
       didChange = true;
     }
     setEditing(false);
     if (didChange) {
-      setNameInput(nameInput);
       setDescInput(descInput);
     }
   };
@@ -150,6 +158,7 @@ const SettingsPane = ({
         <Box p={8} style={{ minWidth: 240 }}>
           <TextInput
             label="Project Name"
+            description="Will be converted to URL-friendly format (lowercase, hyphens)"
             value={nameInput}
             onChange={(e) => setNameInput(e.currentTarget.value)}
             size="xs"
@@ -163,6 +172,10 @@ const SettingsPane = ({
               label: {
                 color: theColorScheme === "dark" ? "#fff" : undefined,
                 fontSize: 12
+              },
+              description: {
+                color: theColorScheme === "dark" ? "#888" : "#666",
+                fontSize: 10
               }
             }}
           />

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "mongoose": "^7.1.0",
         "npm": "^10.5.0",
         "react-icons": "^5.5.0",
+        "slugify": "^1.6.6",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -6242,6 +6243,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/smart-buffer": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mongoose": "^7.1.0",
     "npm": "^10.5.0",
     "react-icons": "^5.5.0",
+    "slugify": "^1.6.6",
     "uuid": "^11.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR installs `slugify` as a dependency to transform project names into strings that are more URL friendly without URL encoding.

<img width="342" height="316" alt="image" src="https://github.com/user-attachments/assets/44ad1e1d-8c51-4a19-af9f-ec16d3594912" />

<img width="594" height="539" alt="image" src="https://github.com/user-attachments/assets/e04c03bd-1cac-4006-af86-752ccf54b3d1" />

Some example transformations:
- Spaces are replaced with `-`.
- `&` is replaced with `and`,
-  `$` is replaced with `dollar`

`slugify` also seems extensible so if we want to customize further that is an option.

Copilot handled the frontend changes. Closes #130 