### PR TITLE
Prettier formatting

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "postcss": "^8.5.5",
         "postcss-preset-mantine": "^1.17.0",
         "postcss-simple-vars": "^7.0.1",
+        "prettier": "^3.6.2",
         "prismjs": "^1.30.0",
         "react": "^19.1.0",
         "react-bootstrap": "^2.7.4",
@@ -4066,6 +4067,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "postcss": "^8.5.5",
     "postcss-preset-mantine": "^1.17.0",
     "postcss-simple-vars": "^7.0.1",
+    "prettier": "^3.6.2",
     "prismjs": "^1.30.0",
     "react": "^19.1.0",
     "react-bootstrap": "^2.7.4",

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -10,7 +10,12 @@ import {
   TextInput,
   Box
 } from "@mantine/core";
-import { PiFloppyDiskBold, PiGitForkBold, PiHouseBold } from "react-icons/pi";
+import {
+  PiFloppyDiskBold,
+  PiGitForkBold,
+  PiHouseBold,
+  PiMagicWandBold
+} from "react-icons/pi";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link, useLocation, useParams } from "react-router-dom";
@@ -41,6 +46,9 @@ const Header = (projectName, getProject) => {
 
   const saveAllFiles = () => {
     window.dispatchEvent(new CustomEvent("saveAllFiles"));
+  };
+  const formatAndSaveAllFiles = () => {
+    window.dispatchEvent(new CustomEvent("formatAndSaveAllFiles"));
   };
   const forkProject = () => {
     window.location.href = `/c/${routeProjectName}`;
@@ -130,6 +138,24 @@ const Header = (projectName, getProject) => {
               </ActionIcon>
             </Tooltip>
           )}
+        </Group>
+      )}
+      {isEditor && (
+        <Group gap={0}>
+          {userIsOwner ? (
+            <Tooltip label="Format with Prettier and Save All">
+              <ActionIcon
+                onClick={formatAndSaveAllFiles}
+                color={primaryColor}
+                size="md"
+                style={{
+                  color: theColorScheme === "dark" ? "#fff" : undefined
+                }}
+              >
+                <PiMagicWandBold />
+              </ActionIcon>
+            </Tooltip>
+          ) : null}
         </Group>
       )}
       <Group gap={0} ml="auto">


### PR DESCRIPTION
This PR introduces a Format with Prettier and Save All button:
<img width="640" height="249" alt="image" src="https://github.com/user-attachments/assets/ec491aef-54ea-4ae6-9741-8c33039c6784" />

Plugins for HTML, CSS and JS are currently imported, but additional parsers are available.

Example of formatting (removing white space in span opening tag:
<img width="1488" height="385" alt="image" src="https://github.com/user-attachments/assets/fa596ab9-25bb-455c-b9f4-ac7975f1188f" />
