### PR TITLE
173 feature add the ability to copy project on create

### DIFF
--- a/backend/controllers/projectController.ts
+++ b/backend/controllers/projectController.ts
@@ -121,7 +121,6 @@ const createProject = asyncHandler(async (req: any, res) => {
   }
 
   let existingProject: IProject = await findProject(copyingProjectName);
-  //rebecca
   const newProjectId: string = uuidv4();
 
   const starterProjectFiles: IProjectFile[] = [

--- a/backend/controllers/projectController.ts
+++ b/backend/controllers/projectController.ts
@@ -23,6 +23,10 @@ const findProject = async (projectName: string): Promise<IProject> => {
       fs.constants.R_OK
     );
     starterExists = true;
+
+    if (projectName === "") {
+      starterExists = false;
+    }
   } catch (e) {
     starterExists = false;
   }
@@ -117,7 +121,7 @@ const createProject = asyncHandler(async (req: any, res) => {
   }
 
   let existingProject: IProject = await findProject(copyingProjectName);
-
+  //rebecca
   const newProjectId: string = uuidv4();
 
   const starterProjectFiles: IProjectFile[] = [
@@ -127,7 +131,8 @@ const createProject = asyncHandler(async (req: any, res) => {
     }
   ];
 
-  const copyProjectFiles: IProjectFile[] | undefined = existingProject && existingProject.projectFiles;
+  const copyProjectFiles: IProjectFile[] | undefined =
+    existingProject && existingProject.projectFiles;
 
   const projectToCreate: IProject = {
     projectName: slugifiedProjectName,

--- a/frontend/src/components/Main/CreateProjectScreen.tsx
+++ b/frontend/src/components/Main/CreateProjectScreen.tsx
@@ -20,6 +20,8 @@ import Logo from "../Interface/Logo";
 const CreateProjectScreen = () => {
   const [projectName, setProjectName] = useState("");
   const [projectDescription, setProjectDescription] = useState("");
+  //rebecca 
+  const [copyingProjectName, setCopyingProjectName] = useState("");
 
   const [createProject, { isLoading }] = useCreateProjectMutation();
 
@@ -30,7 +32,10 @@ const CreateProjectScreen = () => {
     try {
       const res = await createProject({
         projectName,
-        projectDescription
+        projectDescription,
+        //rebecca
+        copyingProjectName
+
       }).unwrap();
       toast.success(res.message);
       window.open(`/e/${res.projectName}`, "_blank");
@@ -101,6 +106,33 @@ const CreateProjectScreen = () => {
                 }
               }}
             />
+            
+             <TextInput
+             //// beginning work
+            /*
+            It should be stored with a new state, copyingProjectName. 
+            It should not be required. When the form is submit, 
+            it should send along copyingProjectName to the 
+            createProject call along with projectName and 
+            projectDescription.
+            */
+              label="Copying Project"
+              description="Enter the name of an existing project to copy"
+              value={copyingProjectName}
+              onChange={(e) => setCopyingProjectName(e.target.value)}
+              mb="md"
+              size="md"
+              autoFocus
+              styles={{
+                input: {
+                  color: theColorSchemeish === "dark" ? "#fff" : undefined
+                },
+                label: {
+                  color: theColorSchemeish === "dark" ? "#fff" : undefined
+                }
+              }}
+            />
+            
             <Textarea
               label="Project Description"
               value={projectDescription}

--- a/frontend/src/components/Main/CreateProjectScreen.tsx
+++ b/frontend/src/components/Main/CreateProjectScreen.tsx
@@ -20,7 +20,6 @@ import Logo from "../Interface/Logo";
 const CreateProjectScreen = () => {
   const [projectName, setProjectName] = useState("");
   const [projectDescription, setProjectDescription] = useState("");
-  //rebecca 
   const [copyingProjectName, setCopyingProjectName] = useState("");
 
   const [createProject, { isLoading }] = useCreateProjectMutation();
@@ -33,7 +32,6 @@ const CreateProjectScreen = () => {
       const res = await createProject({
         projectName,
         projectDescription,
-        //rebecca
         copyingProjectName
 
       }).unwrap();
@@ -108,14 +106,6 @@ const CreateProjectScreen = () => {
             />
             
              <TextInput
-             //// beginning work
-            /*
-            It should be stored with a new state, copyingProjectName. 
-            It should not be required. When the form is submit, 
-            it should send along copyingProjectName to the 
-            createProject call along with projectName and 
-            projectDescription.
-            */
               label="Copying Project"
               description="Enter the name of an existing project to copy"
               value={copyingProjectName}


### PR DESCRIPTION
changed the frontend to incorporate copyProjectName variable and button. 
changed the backend to check if projectname is blank when searching to see if the projectname already existed