### PR TITLE
input validation on file creation

### DIFF
--- a/backend/controllers/projectController.ts
+++ b/backend/controllers/projectController.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import { IProject, IProjectFile } from "../../shared/types";
 import slugify from "slugify";
 import User from "../models/userModel";
+import { readdirSync } from "node:fs";
 
 const slugifyProjectName = (unsluggedName: string): string => {
   return slugify(unsluggedName, {
@@ -18,17 +19,12 @@ const slugifyProjectName = (unsluggedName: string): string => {
 const findProject = async (projectName: string): Promise<IProject> => {
   let starterExists: boolean = false;
   try {
-    await fs.promises.access(
-      `./backend/starters/${projectName}`,
-      fs.constants.R_OK
-    );
-    starterExists = true;
-
-    if (projectName === "") {
-      starterExists = false;
+    let starters = readdirSync("./backend/starters");
+    if (starters.includes(projectName)) {
+      starterExists = true;
     }
   } catch (e) {
-    starterExists = false;
+    throw new Error(e);
   }
 
   if (starterExists) {
@@ -536,7 +532,7 @@ const getProjectId = asyncHandler(async (req: any, res) => {
   res.json({ projectId: project.projectId });
 });
 
-// @desc    Render a project file
+// @desc    Render a project file, shows code for when you click on the file
 // @route   GET /pf/:projectName/:filename
 // @access  Public
 const renderFile = asyncHandler(async (req: any, res) => {

--- a/frontend/src/components/ProjectView/SideBar/FileSelector/FileSelectorComponent.tsx
+++ b/frontend/src/components/ProjectView/SideBar/FileSelector/FileSelectorComponent.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useUpdateProjectMutation } from "../../../../slices/projectsApiSlice";
 import { useParams } from "react-router-dom";
 import { RootState } from "../../../../store";
-import {toast} from "react-toastify";
+import { toast } from "react-toastify";
 import {
   setActiveTab,
   setProjectFiles,
@@ -29,7 +29,7 @@ const FileSelectorComponent = ({ closePane, userIsOwner }) => {
     activeTab,
     unsavedFiles
   } = useSelector((state: RootState) => state.editor);
- 
+
   const theColorScheme = useComputedColorScheme("light");
   const [updateProject] = useUpdateProjectMutation();
 
@@ -86,7 +86,7 @@ const FileSelectorComponent = ({ closePane, userIsOwner }) => {
       dispatch(setUnsavedFiles({}));
       dispatch(setProjectFiles(updatedFiles));
     } catch (err) {
-      toast.error("Error saving project, please manually save.")
+      toast.error("Error saving project, please manually save.");
     }
   };
 
@@ -108,7 +108,7 @@ const FileSelectorComponent = ({ closePane, userIsOwner }) => {
       dispatch(setUnsavedFiles({}));
       dispatch(setProjectFiles(updatedFiles));
     } catch (err) {}
-    dispatch(openTab(newFileName))
+    dispatch(openTab(newFileName));
   };
 
   return (

--- a/frontend/src/components/ProjectView/SideBar/FileSelector/FilesHeader.tsx
+++ b/frontend/src/components/ProjectView/SideBar/FileSelector/FilesHeader.tsx
@@ -8,6 +8,7 @@ import {
 import { SIDEBAR_ICON_MAP } from "../../constants";
 import { PiCheckBold, PiFilePlusBold, PiXBold } from "react-icons/pi";
 import { useState } from "react";
+import { toast } from "react-toastify";
 
 const FilesHeader = ({
   enableAddFile,
@@ -29,7 +30,19 @@ const FilesHeader = ({
   };
 
   const handleSubmitNewFile = () => {
+    // TODO: this honestly should hold more validation before submitting
     if (isDuplicateRename(newFileName)) {
+      toast.error("File already exists");
+      return;
+    }
+
+    if (newFileName.length == 0) {
+      toast.error("File must have a name");
+      return;
+    }
+
+    if (newFileName.includes("/")) {
+      toast.error("File name may not contain a '/'");
       return;
     }
 
@@ -37,7 +50,7 @@ const FilesHeader = ({
     setNewFileName("");
     setAddingNewFile(false);
   };
-  
+
   return (
     <Group
       align="apart"


### PR DESCRIPTION
errors on all file names including a slash, empty file names, and adding a note to add future validation
also made `findProject()` more robust, as I originally thought that was the source of the error, but using the node built in methods should be better so I say we keep it regardless :)