### PR TITLE
filenames no longer case sensitive

### DIFF
--- a/backend/controllers/projectController.ts
+++ b/backend/controllers/projectController.ts
@@ -9,6 +9,11 @@ import User from "../models/userModel";
 import { readdirSync } from "node:fs";
 import { runPyThroughHTML } from "./runPy";
 
+/**
+ * If you're handling any request that involve getting the project name MAKE SURE you slugify it.
+ * For example, trying to access MyFirstProject vs myfirstproject will not work. 
+ * Slugifying it will make it so that it's not case sensitive.
+ */
 const slugifyProjectName = (unsluggedName: string): string => {
   return slugify(unsluggedName, {
     replacement: "-",
@@ -194,10 +199,11 @@ const copyProject = asyncHandler(async (req: any, res) => {
   const userId = getUserId(req, res);
 
   const { projectName } = req.body;
+  const slugifiedProjectName = slugifyProjectName(projectName);
   let existingProject: IProject;
 
   try {
-    existingProject = await findProject(projectName);
+    existingProject = await findProject(slugifiedProjectName);
   } catch (e) {
     res.status(400);
     throw new Error(":( project not found :(");
@@ -209,7 +215,7 @@ const copyProject = asyncHandler(async (req: any, res) => {
 
   try {
     newProjectName = await generateNewProjectName(
-      removeTrailingDigits(projectName)
+      removeTrailingDigits(slugifiedProjectName)
     );
   } catch (error) {
     res.status(400);
@@ -243,7 +249,7 @@ const copyProject = asyncHandler(async (req: any, res) => {
 });
 
 export const getForksOfProject = asyncHandler(async (req: any, res) => {
-  const projectName: string = req.params.projectName;
+  const projectName: string = slugifyProjectName(req.params.projectName);
   let projectId: string;
 
   try {
@@ -271,7 +277,7 @@ export const getForksOfProject = asyncHandler(async (req: any, res) => {
 // @access  NOT Public
 const checkOwnership = asyncHandler(async (req: any, res) => {
   const user = req.user;
-  const projectName: string = req.params.projectName;
+  const projectName: string = slugifyProjectName(req.params.projectName);
 
   const existingProject: IProject = await findProject(projectName);
   if (!existingProject) {
@@ -438,7 +444,7 @@ const changeProjectDescription = asyncHandler(async (req: any, res) => {
 // @access  NOT Public
 const updateProject = asyncHandler(async (req: any, res) => {
   const user = req.user;
-  const projectName: string = req.body.projectName;
+  const projectName: string = slugifyProjectName(req.body.projectName);
   const projectFiles: IProjectFile[] = req.body.projectFiles;
 
   const existingProject = await findProject(projectName);
@@ -495,7 +501,7 @@ const getLatest = asyncHandler(async (req: any, res) => {
 // @route   GET /get/:projectId
 // @access  Public
 const getProject = asyncHandler(async (req: any, res) => {
-  const projectName: string = req.params.projectName;
+  const projectName: string = slugifyProjectName(req.params.projectName);
   let project: IProject & { ownerUsername?: string };
   let ownerUsername: string;
 
@@ -522,7 +528,7 @@ const getProject = asyncHandler(async (req: any, res) => {
 });
 
 const getProjectId = asyncHandler(async (req: any, res) => {
-  const projectName: string = req.params.projectName;
+  const projectName: string = slugifyProjectName(req.params.projectName);
   let project: IProject;
 
   try {
@@ -539,7 +545,7 @@ const getProjectId = asyncHandler(async (req: any, res) => {
 // @route   GET /pf/:projectName/:filename
 // @access  Public
 const renderFile = asyncHandler(async (req: any, res) => {
-  const projectName: string = req.params.projectName;
+  const projectName: string = slugifyProjectName(req.params.projectName);
   let fileName: string = req.params.filename;
   let project: IProject;
 


### PR DESCRIPTION
- Filenames are no longer case sensitive, so accessing MyFirstProject and myfirstproject will give you the same files.
- Updated projectController so that any function accessing the project name will make sure that it's slugified before using the value anywhere else. 
- Added documentation to the slugifyProjectName function in projectController.ts so future developers will know when to use it. 